### PR TITLE
Implement Vexa core playback functionality

### DIFF
--- a/services/bot-manager/app/main.py
+++ b/services/bot-manager/app/main.py
@@ -238,6 +238,15 @@ class BotStatusChangePayload(BaseModel):
     failure_stage: Optional[MeetingFailureStage] = Field(None, description="Stage where failure occurred if applicable.")
     timestamp: Optional[str] = Field(None, description="Timestamp of the status change.")
 
+# --- Playback Request Model ---
+class PlaybackRequest(BaseModel):
+    """Request body for queueing audio playback to a running bot via Redis."""
+    audio_b64: str = Field(..., description="Base64-encoded audio data (prefer WAV/PCM16).")
+    job_id: Optional[str] = Field(None, description="Optional playback job identifier for client-side correlation.")
+    chunk_index: Optional[int] = Field(None, description="Optional chunk index if streaming in parts.")
+    total_chunks: Optional[int] = Field(None, description="Optional total number of chunks if known.")
+    end: Optional[bool] = Field(None, description="If true, marks this as the final chunk of the job.")
+
 # --- --------------------------------------------- ---
 
 @app.on_event("startup")
@@ -680,6 +689,90 @@ async def update_bot_config(
     # 4. Return 202 Accepted
     return {"message": "Reconfiguration request accepted and sent to the bot."}
 # -------------------------------------------
+
+# --- NEW Endpoint: Queue audio playback to an active bot ---
+@app.post("/playback/{platform}/{native_meeting_id}",
+          status_code=status.HTTP_202_ACCEPTED,
+          summary="Queue audio playback for an active bot",
+          description="Publishes audio playback jobs to the bot via Redis Pub/Sub so the bot can play the audio into the call.",
+          dependencies=[Depends(get_user_and_token)])
+async def queue_playback(
+    platform: Platform,
+    native_meeting_id: str,
+    req: PlaybackRequest,
+    auth_data: tuple[str, User] = Depends(get_user_and_token),
+    db: AsyncSession = Depends(get_db)
+):
+    global redis_client
+    user_token, current_user = auth_data
+
+    # Validate base64 payload is reasonably sized
+    if not isinstance(req.audio_b64, str) or len(req.audio_b64.strip()) == 0:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="audio_b64 is required")
+
+    # Resolve latest active or requested meeting to get session uid mapping
+    stmt = select(Meeting).where(
+        Meeting.user_id == current_user.id,
+        Meeting.platform == platform.value,
+        Meeting.platform_specific_id == native_meeting_id,
+        Meeting.status.in_([
+            MeetingStatus.ACTIVE.value,
+            MeetingStatus.JOINING.value,
+            MeetingStatus.AWAITING_ADMISSION.value,
+            MeetingStatus.REQUESTED.value
+        ])
+    ).order_by(desc(Meeting.created_at))
+
+    result = await db.execute(stmt)
+    meeting = result.scalars().first()
+    if not meeting:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No active or pending meeting found for playback")
+
+    # Find current session uid from Redis mapping, fallback to latest session
+    session_uid: Optional[str] = None
+    try:
+        if redis_client:
+            mapping_key = f"bm:meeting:{platform.value}:{native_meeting_id}:current_uid"
+            mapped = await redis_client.get(mapping_key)
+            if isinstance(mapped, str) and mapped:
+                session_uid = mapped
+    except Exception as e:
+        logger.warning(f"[Playback] Failed to read current_uid mapping: {e}")
+
+    if not session_uid:
+        latest_session_stmt = select(MeetingSession.session_uid).where(
+            MeetingSession.meeting_id == meeting.id
+        ).order_by(MeetingSession.session_start_time.desc()).limit(1)
+        sr = await db.execute(latest_session_stmt)
+        session_uid = sr.scalars().first()
+
+    if not session_uid:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Playback not possible: no active session UID")
+
+    if not redis_client:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Internal messaging unavailable")
+
+    # Construct playback command and publish to bot channel
+    command_channel = f"bot_commands:{session_uid}"
+    command_payload = {
+        "action": "playback",
+        "job_id": req.job_id,
+        "chunk_index": req.chunk_index,
+        "total_chunks": req.total_chunks,
+        "end": bool(req.end) if req.end is not None else None,
+        "audio_b64": req.audio_b64
+    }
+
+    try:
+        payload_str = json.dumps(command_payload)
+        await redis_client.publish(command_channel, payload_str)
+        logger.info(f"[Playback] Published playback command to {command_channel} job={req.job_id} chunk={req.chunk_index}/{req.total_chunks}")
+    except Exception as e:
+        logger.error(f"[Playback] Failed to publish playback command: {e}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to enqueue playback command")
+
+    return {"message": "Playback enqueued", "channel": command_channel, "job_id": req.job_id, "chunk_index": req.chunk_index}
+
 
 @app.delete("/bots/{platform}/{native_meeting_id}",
              status_code=status.HTTP_202_ACCEPTED,

--- a/services/vexa-bot/core/src/index.ts
+++ b/services/vexa-bot/core/src/index.ts
@@ -183,6 +183,158 @@ const handleRedisMessage = async (message: string, channel: string, page: Page |
           } else {
                log("Page not available or closed, cannot send reconfigure command to browser.");
           }
+      } else if (command.action === 'playback') {
+        // Playback audio into the meeting using browser AudioContext queue
+        if (page && !page.isClosed()) {
+          try {
+            await page.evaluate(async (payload) => {
+              try {
+                (window as any).logBot?.(`[Playback] Received playback payload job=${payload?.job_id} chunk=${payload?.chunk_index}/${payload?.total_chunks}`);
+
+                // Lazy initialize playback mixer
+                const initMixer = async () => {
+                  if (!(window as any).__vexaPlayback) {
+                    (window as any).__vexaPlayback = {
+                      ac: new (window as any).AudioContext(),
+                      queue: [] as Array<{buffer: AudioBuffer, jobId: string|null}>,
+                      playing: false,
+                      gain: null as GainNode | null,
+                      merger: null as ChannelMergerNode | null,
+                      destination: null as MediaStreamAudioDestinationNode | null,
+                      micUnmuted: false,
+                      unmuteMicSelectors: [
+                        '[aria-label*="Turn on microphone"]',
+                        'button[aria-label*="Turn on microphone"]',
+                        '[aria-label*="Unmute"]',
+                        'button[aria-label*="Unmute"]'
+                      ],
+                      muteMicSelectors: [
+                        '[aria-label*="Turn off microphone"]',
+                        'button[aria-label*="Turn off microphone"]',
+                        '[aria-label*="Mute"]',
+                        'button[aria-label*="Mute"]'
+                      ]
+                    };
+                    const P = (window as any).__vexaPlayback;
+                    P.gain = P.ac.createGain();
+                    P.gain.gain.value = 1.0;
+                    P.destination = P.ac.createMediaStreamDestination();
+                    P.gain.connect(P.destination);
+                    try { await P.ac.resume(); } catch {}
+
+                    // Try to attach to any existing <audio>/<video> elements if needed
+                    try {
+                      const els = Array.from(document.querySelectorAll('audio,video')) as HTMLMediaElement[];
+                      els.forEach(el => {
+                        try { el.muted = false; el.volume = 1.0; el.play?.(); } catch {}
+                      });
+                    } catch {}
+
+                    // Best-effort: expose small helpers
+                    (window as any).__vexaPlaybackPlayNext = async () => {
+                      const P2 = (window as any).__vexaPlayback;
+                      if (!P2 || P2.playing) return;
+                      const item = P2.queue.shift();
+                      if (!item) { P2.playing = false; return; }
+                      P2.playing = true;
+                      const src = P2.ac.createBufferSource();
+                      src.buffer = item.buffer;
+                      src.connect(P2.gain!);
+                      src.onended = () => {
+                        P2.playing = false;
+                        (window as any).__vexaPlaybackPlayNext?.();
+                      };
+                      try { src.start(0); } catch {}
+                    };
+
+                    // mic control best-effort
+                    (window as any).__vexaPlaybackUnmuteMic = () => {
+                      const P3 = (window as any).__vexaPlayback;
+                      if (!P3) return;
+                      try {
+                        for (const sel of P3.unmuteMicSelectors) {
+                          const btn = document.querySelector(sel) as HTMLElement | null;
+                          if (btn) { btn.click(); P3.micUnmuted = true; break; }
+                        }
+                      } catch {}
+                    };
+                    (window as any).__vexaPlaybackMuteMic = () => {
+                      const P3 = (window as any).__vexaPlayback;
+                      if (!P3) return;
+                      try {
+                        for (const sel of P3.muteMicSelectors) {
+                          const btn = document.querySelector(sel) as HTMLElement | null;
+                          if (btn) { btn.click(); P3.micUnmuted = false; break; }
+                        }
+                      } catch {}
+                    };
+                  }
+                };
+
+                await initMixer();
+                const P = (window as any).__vexaPlayback;
+
+                // Decode base64 audio into AudioBuffer
+                const b64 = payload?.audio_b64 || '';
+                if (!b64 || typeof b64 !== 'string') return;
+                const binary = atob(b64);
+                const len = binary.length;
+                const bytes = new Uint8Array(len);
+                for (let i = 0; i < len; i++) bytes[i] = binary.charCodeAt(i);
+                const audioBuffer = await P.ac.decodeAudioData(bytes.buffer).catch(async () => {
+                  // Fallback: try to decode via <audio> element if decodeAudioData fails
+                  return await new Promise<AudioBuffer>((resolve, reject) => {
+                    try {
+                      const blob = new Blob([bytes.buffer], { type: 'audio/wav' });
+                      const url = URL.createObjectURL(blob);
+                      const el = new Audio();
+                      el.src = url;
+                      el.oncanplay = async () => {
+                        try {
+                          const ctx = P.ac;
+                          const rs = ctx.createMediaElementSource(el);
+                          rs.connect(P.gain!);
+                          await el.play().catch(() => {});
+                          // Not an AudioBuffer path, but at least it will play out
+                          resolve(ctx.createBuffer(1, 1, ctx.sampleRate));
+                        } catch (e) { reject(e as any); }
+                      };
+                      el.onerror = () => reject(new Error('media element decode failed'));
+                    } catch (e) { reject(e as any); }
+                  });
+                });
+
+                if (audioBuffer) {
+                  // Unmute mic before enqueue first item to ensure audio is sent into call if platform uses mic path
+                  try { (window as any).__vexaPlaybackUnmuteMic?.(); } catch {}
+                  P.queue.push({ buffer: audioBuffer, jobId: payload?.job_id || null });
+                  (window as any).__vexaPlaybackPlayNext?.();
+                }
+
+                // If this is the last chunk of a job and queue drains, optionally mute again
+                if (payload?.end === true) {
+                  // Poll until queue drained and not playing, then mute
+                  const tryMuteWhenIdle = () => {
+                    const Px = (window as any).__vexaPlayback;
+                    if (!Px) return;
+                    if (!Px.playing && Px.queue.length === 0) {
+                      try { (window as any).__vexaPlaybackMuteMic?.(); } catch {}
+                    } else {
+                      setTimeout(tryMuteWhenIdle, 300);
+                    }
+                  };
+                  setTimeout(tryMuteWhenIdle, 300);
+                }
+              } catch (err) {
+                (window as any).logBot?.(`[Playback] Error in browser playback: ${(err as any)?.message || err}`);
+              }
+            }, command);
+          } catch (err: any) {
+            log(`[Playback] Error delivering playback to page: ${err?.message}`);
+          }
+        } else {
+          log("Page not available or closed, cannot process playback command.");
+        }
       } else if (command.action === 'leave') {
         // Mark that a stop was requested via Redis
         stopSignalReceived = true;


### PR DESCRIPTION
Add a `/playback` endpoint to `bot-manager` to queue audio playback jobs via Redis.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d709d28-937c-41f9-ad63-dbcc1487dadc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d709d28-937c-41f9-ad63-dbcc1487dadc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

