### PR TITLE
Implement audio playback queue

### DIFF
--- a/services/vexa-bot/core/build-browser-utils.js
+++ b/services/vexa-bot/core/build-browser-utils.js
@@ -32,7 +32,8 @@ ${browserUtilsContent}
   window.VexaBrowserUtils = {
     BrowserAudioService: utils.BrowserAudioService,
     BrowserWhisperLiveService: utils.BrowserWhisperLiveService,
-    generateBrowserUUID: utils.generateBrowserUUID
+    generateBrowserUUID: utils.generateBrowserUUID,
+    initializePlaybackInjector: utils.initializePlaybackInjector
   };
 
   // Also expose performLeaveAction for platform-specific leave UX
@@ -61,5 +62,6 @@ console.log('📦 Bundle includes:');
 console.log('  - BrowserAudioService');
 console.log('  - BrowserWhisperLiveService');
 console.log('  - generateBrowserUUID');
+console.log('  - initializePlaybackInjector');
 console.log('  - window.VexaBrowserUtils');
 console.log('  - window.performLeaveAction');

--- a/services/vexa-bot/core/src/index.ts
+++ b/services/vexa-bot/core/src/index.ts
@@ -195,6 +195,39 @@ const handleRedisMessage = async (message: string, channel: string, page: Page |
         } else {
            log("Ignoring leave command: Already shutting down or page unavailable.")
         }
+      } else if (command.action === 'playback') {
+        // Forward playback chunk to browser playback injector
+        log("Received playback command; forwarding to browser injector");
+        if (page && !page.isClosed()) {
+          try {
+            const forwarded = await page.evaluate((payload) => {
+              try {
+                const pb = (window as any).__vexaPlayback;
+                if (!pb || typeof pb.queueChunk !== 'function') {
+                  console.warn('[Playback] Module not initialized in browser context');
+                  return false;
+                }
+                pb.queueChunk(payload);
+                if (typeof pb.ensureDrain === 'function') pb.ensureDrain();
+                return true;
+              } catch (e) {
+                console.error('[Playback] Error queuing chunk in browser:', (e as any)?.message || e);
+                return false;
+              }
+            }, {
+              job_id: command.job_id || null,
+              chunk_index: command.chunk_index ?? null,
+              total_chunks: command.total_chunks ?? null,
+              end: command.end ?? null,
+              audio_b64: command.audio_b64
+            });
+            log(`Playback forward ${forwarded ? 'succeeded' : 'failed'}`);
+          } catch (evalErr: any) {
+            log(`Error forwarding playback to browser: ${evalErr.message}`);
+          }
+        } else {
+          log('Page not available or closed; cannot forward playback command');
+        }
       }
   } catch (e: any) {
       log(`Error processing Redis message: ${e.message}`);

--- a/services/vexa-bot/core/src/platforms/googlemeet/recording.ts
+++ b/services/vexa-bot/core/src/platforms/googlemeet/recording.ts
@@ -150,6 +150,9 @@ export async function startGoogleRecording(page: Page, botConfig: BotConfig): Pr
       } catch {}
       // ---------------------------------------------
       
+      // Initialize playback injector to enable speaking into the call
+      try { browserUtils.initializePlaybackInjector?.(); } catch {}
+
       const audioService = new browserUtils.BrowserAudioService({
         targetSampleRate: 16000,
         bufferSize: 4096,

--- a/services/vexa-bot/core/src/platforms/msteams/recording.ts
+++ b/services/vexa-bot/core/src/platforms/msteams/recording.ts
@@ -59,7 +59,7 @@ export async function startTeamsRecording(page: Page, botConfig: BotConfig): Pro
       const selectorsTyped = selectors as any;
 
       // Use browser utility classes from the global bundle
-      const { BrowserAudioService, BrowserWhisperLiveService } = (window as any).VexaBrowserUtils;
+      const { BrowserAudioService, BrowserWhisperLiveService, initializePlaybackInjector } = (window as any).VexaBrowserUtils;
 
       // --- Early reconfigure wiring (event listener only) ---
       (window as any).__vexaPendingReconfigure = null;
@@ -75,6 +75,9 @@ export async function startTeamsRecording(page: Page, botConfig: BotConfig): Pro
       } catch {}
       // ---------------------------------------------
       
+      // Initialize playback injector so queued audio can be played into the call
+      try { initializePlaybackInjector?.(); } catch {}
+
       const audioService = new BrowserAudioService({
         targetSampleRate: 16000,
         bufferSize: 4096,

--- a/services/vexa-bot/core/src/utils/browser.ts
+++ b/services/vexa-bot/core/src/utils/browser.ts
@@ -530,3 +530,170 @@ export class BrowserWhisperLiveService {
     }
   }
 }
+
+/**
+ * Browser-side playback injector to send queued audio into the call microphone.
+ * Exposes window.__vexaPlayback with queueChunk({audio_b64, job_id, chunk_index, total_chunks, end}) and ensureDrain().
+ */
+export function initializePlaybackInjector(): void {
+  try {
+    if ((window as any).__vexaPlayback && typeof (window as any).__vexaPlayback.queueChunk === 'function') {
+      return; // already initialized
+    }
+
+    // Light instrumentation to track RTCPeerConnections and senders
+    try {
+      if (!(window as any).peerConnections && typeof (window as any).RTCPeerConnection === 'function') {
+        (window as any).peerConnections = [];
+        const OrigPC = (window as any).RTCPeerConnection;
+        (window as any).RTCPeerConnection = function(...args: any[]) {
+          const pc = new (OrigPC as any)(...args);
+          try { (window as any).peerConnections.push(pc); } catch {}
+          return pc;
+        } as any;
+        // Preserve prototype
+        (window as any).RTCPeerConnection.prototype = OrigPC.prototype;
+      }
+    } catch {}
+
+    const state: any = {
+      audioContext: null as AudioContext | null,
+      destination: null as MediaStreamAudioDestinationNode | null,
+      source: null as AudioBufferSourceNode | null,
+      mediaStream: null as MediaStream | null,
+      // Queue of jobs: each job has array of AudioBuffer parts to play sequentially
+      jobBuffers: new Map<string, { buffers: AudioBuffer[]; expected: number | null; received: number; done: boolean }>(),
+      jobOrder: [] as string[],
+      playing: false,
+      senderReplaced: false,
+    };
+
+    const ensureContext = async () => {
+      if (!state.audioContext) state.audioContext = new AudioContext();
+      if (state.audioContext.state === 'suspended') {
+        try { await state.audioContext.resume(); } catch {}
+      }
+      if (!state.destination) state.destination = state.audioContext.createMediaStreamDestination();
+      if (!state.mediaStream) state.mediaStream = state.destination.stream;
+    };
+
+    const base64ToArrayBuffer = (b64: string): ArrayBuffer => {
+      const binary = atob(b64);
+      const len = binary.length;
+      const bytes = new Uint8Array(len);
+      for (let i = 0; i < len; i++) bytes[i] = binary.charCodeAt(i);
+      return bytes.buffer;
+    };
+
+    const decodeToBuffer = async (audio_b64: string): Promise<AudioBuffer> => {
+      await ensureContext();
+      const arr = base64ToArrayBuffer(audio_b64);
+      return await state.audioContext!.decodeAudioData(arr.slice(0));
+    };
+
+    const tryReplaceMicSender = async () => {
+      try {
+        const pc = (window as any).RTCPeerConnection && (window as any).__vexaPeerConnection ? (window as any).__vexaPeerConnection : null;
+        let senders: RTCRtpSender[] | null = null;
+        // Heuristic: try to discover an existing connection
+        if (!pc) {
+          const candidates = (window as any).peerConnections || [];
+          if (Array.isArray(candidates) && candidates.length) {
+            senders = candidates[0].getSenders?.() || null;
+          }
+        } else {
+          senders = pc.getSenders?.() || null;
+        }
+        if (!senders || !senders.length) return false;
+        const micSender = senders.find(s => s.track && s.track.kind === 'audio');
+        if (!micSender) return false;
+        await ensureContext();
+        const outgoingTrack = state.mediaStream!.getAudioTracks()[0];
+        if (!outgoingTrack) return false;
+        if ((micSender as any).replaceTrack) {
+          await (micSender as any).replaceTrack(outgoingTrack);
+          state.senderReplaced = true;
+          return true;
+        }
+        return false;
+      } catch {
+        return false;
+      }
+    };
+
+    const playNextBuffer = async (): Promise<void> => {
+      if (state.playing) return;
+      await ensureContext();
+
+      // Find the next available buffer across jobOrder
+      while (state.jobOrder.length > 0) {
+        const currentJobId = state.jobOrder[0];
+        const job = state.jobBuffers.get(currentJobId);
+        if (!job) { state.jobOrder.shift(); continue; }
+        if (job.buffers.length === 0) {
+          if (job.done || (job.expected !== null && job.received >= job.expected)) {
+            state.jobBuffers.delete(currentJobId);
+            state.jobOrder.shift();
+            continue;
+          } else {
+            // wait for more chunks for this job
+            return;
+          }
+        }
+
+        // There is a buffer to play
+        const buffer = job.buffers.shift()!;
+        try { await state.audioContext!.resume(); } catch {}
+        const src = state.audioContext!.createBufferSource();
+        src.buffer = buffer;
+        src.connect(state.destination!);
+        state.source = src;
+        state.playing = true;
+        src.onended = () => {
+          state.playing = false;
+          state.source = null;
+          // Continue with next buffer or job
+          setTimeout(() => { playNextBuffer().catch(() => {}); }, 0);
+        };
+        src.start();
+        // Attempt to hook to outgoing mic track once playback starts
+        if (!state.senderReplaced) {
+          tryReplaceMicSender().catch(() => {});
+        }
+        return; // actively playing
+      }
+      // Nothing to play
+    };
+
+    const queueChunk = async (payload: any) => {
+      const jobId: string = payload?.job_id || 'default';
+      const chunkIndex = payload?.chunk_index;
+      const total = payload?.total_chunks;
+      const end = !!payload?.end;
+      const b64: string = payload?.audio_b64;
+      if (!b64 || typeof b64 !== 'string') return;
+
+      try {
+        const buf = await decodeToBuffer(b64);
+        if (!state.jobBuffers.has(jobId)) {
+          state.jobBuffers.set(jobId, { buffers: [], expected: (typeof total === 'number' ? total : null), received: 0, done: false });
+          if (!state.jobOrder.includes(jobId)) state.jobOrder.push(jobId);
+        }
+        const job = state.jobBuffers.get(jobId)!;
+        job.buffers.push(buf);
+        job.received += 1;
+        if (end) job.done = true;
+      } catch (e) {
+        // ignore decode errors
+      }
+    };
+
+    const ensureDrain = () => {
+      playNextBuffer().catch(() => {});
+    };
+
+    (window as any).__vexaPlayback = { queueChunk, ensureDrain };
+  } catch (e) {
+    try { (window as any).logBot?.(`[Playback] Initialization error: ${(e as any)?.message || e}`); } catch {}
+  }
+}


### PR DESCRIPTION
Add browser-side audio playback to inject queued audio into the live call's microphone stream.

This PR introduces a browser-side WebAudio pipeline that captures the outgoing microphone track and replaces it with a stream generated from queued audio chunks. A new Redis command `playback` allows the bot to send base64 encoded audio to the browser, which then decodes, queues, and plays these chunks sequentially into the call.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d2caf9c-4874-494b-87f5-9faae3bce44a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2d2caf9c-4874-494b-87f5-9faae3bce44a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

